### PR TITLE
Update PluginConfig.cs - Fix null reference

### DIFF
--- a/src/PluginConfig.cs
+++ b/src/PluginConfig.cs
@@ -455,7 +455,7 @@ namespace KeePassSyncForDrive
 			{
 				configVersion = new Version(Ver0);
 			}
-			update.ConfigVersion = configVersion;
+			update.ConfigVersion = configVersion.ToString(2);
 
 			string cmds = host.GetConfig(ConfigEnabledCmdsKey,
 				((int)SyncCommands.All).ToString(

--- a/src/PluginConfig.cs
+++ b/src/PluginConfig.cs
@@ -454,8 +454,8 @@ namespace KeePassSyncForDrive
 			if (!Version.TryParse(verString, out configVersion))
 			{
 				configVersion = new Version(Ver0);
-				update.ConfigVersion = Ver0;
 			}
+			update.ConfigVersion = configVersion;
 
 			string cmds = host.GetConfig(ConfigEnabledCmdsKey,
 				((int)SyncCommands.All).ToString(


### PR DESCRIPTION
Fixes #29

Method `UpdateConfig` dumps because of `configVer = new Version(ConfigVersion);`
ConfigVersion is null, if GoogleSync.ConfigVersion can be read in method `InitLegacyDefault`