### PR TITLE
GDrive File Scope implementation with file picker

### DIFF
--- a/src/ConfigurationForm.Designer.cs
+++ b/src/ConfigurationForm.Designer.cs
@@ -67,7 +67,7 @@
             this.m_chkDontSaveAuthToken = new System.Windows.Forms.CheckBox();
             this.m_grpFileScope = new System.Windows.Forms.GroupBox();
             this.m_btnSelectFile = new System.Windows.Forms.Button();
-            this.m_txtFile = new System.Windows.Forms.TextBox();
+            this.m_txtTargetFile = new System.Windows.Forms.TextBox();
             this.m_lblTargetFile = new System.Windows.Forms.Label();
             this.m_chkUseFileScope = new System.Windows.Forms.CheckBox();
             this.m_grpDriveAuth = new System.Windows.Forms.GroupBox();
@@ -500,7 +500,7 @@
             // m_grpFileScope
             // 
             this.m_grpFileScope.Controls.Add(this.m_btnSelectFile);
-            this.m_grpFileScope.Controls.Add(this.m_txtFile);
+            this.m_grpFileScope.Controls.Add(this.m_txtTargetFile);
             this.m_grpFileScope.Controls.Add(this.m_lblTargetFile);
             this.m_grpFileScope.Controls.Add(this.m_chkUseFileScope);
             this.m_grpFileScope.Location = new System.Drawing.Point(6, 182);
@@ -518,12 +518,12 @@
             this.m_btnSelectFile.Text = "Btn_SelectFile";
             this.m_btnSelectFile.UseVisualStyleBackColor = true;
             // 
-            // m_txtFile
+            // m_txtTargetFile
             // 
-            this.m_txtFile.Location = new System.Drawing.Point(131, 35);
-            this.m_txtFile.Name = "m_txtFile";
-            this.m_txtFile.Size = new System.Drawing.Size(289, 20);
-            this.m_txtFile.TabIndex = 33;
+            this.m_txtTargetFile.Location = new System.Drawing.Point(131, 35);
+            this.m_txtTargetFile.Name = "m_txtTargetFile";
+            this.m_txtTargetFile.Size = new System.Drawing.Size(289, 20);
+            this.m_txtTargetFile.TabIndex = 33;
             // 
             // m_lblTargetFile
             // 
@@ -961,6 +961,6 @@
         private System.Windows.Forms.GroupBox m_grpFileScope;
         private System.Windows.Forms.Label m_lblTargetFile;
         private System.Windows.Forms.Button m_btnSelectFile;
-        private System.Windows.Forms.TextBox m_txtFile;
+        private System.Windows.Forms.TextBox m_txtTargetFile;
     }
 }

--- a/src/ConfigurationForm.Designer.cs
+++ b/src/ConfigurationForm.Designer.cs
@@ -65,6 +65,11 @@
             this.m_grpAuthTokenSecurity = new System.Windows.Forms.GroupBox();
             this.m_lnkAuthTokenHelp = new System.Windows.Forms.LinkLabel();
             this.m_chkDontSaveAuthToken = new System.Windows.Forms.CheckBox();
+            this.m_grpFileScope = new System.Windows.Forms.GroupBox();
+            this.m_btnSelectFile = new System.Windows.Forms.Button();
+            this.m_txtFile = new System.Windows.Forms.TextBox();
+            this.m_lblTargetFile = new System.Windows.Forms.Label();
+            this.m_chkUseFileScope = new System.Windows.Forms.CheckBox();
             this.m_grpDriveAuth = new System.Windows.Forms.GroupBox();
             this.m_chkUseLegacyCreds = new System.Windows.Forms.CheckBox();
             this.m_chkDriveScope = new System.Windows.Forms.CheckBox();
@@ -102,6 +107,7 @@
             this.m_grpAutoSync.SuspendLayout();
             this.m_tabGSignIn.SuspendLayout();
             this.m_grpAuthTokenSecurity.SuspendLayout();
+            this.m_grpFileScope.SuspendLayout();
             this.m_grpDriveAuth.SuspendLayout();
             this.m_grpEntry.SuspendLayout();
             this.m_grpDriveOptions.SuspendLayout();
@@ -114,7 +120,7 @@
             // m_btnCancel
             // 
             this.m_btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.m_btnCancel.Location = new System.Drawing.Point(497, 522);
+            this.m_btnCancel.Location = new System.Drawing.Point(493, 615);
             this.m_btnCancel.Name = "m_btnCancel";
             this.m_btnCancel.Size = new System.Drawing.Size(75, 23);
             this.m_btnCancel.TabIndex = 102;
@@ -124,7 +130,7 @@
             // m_btnOK
             // 
             this.m_btnOK.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.m_btnOK.Location = new System.Drawing.Point(416, 522);
+            this.m_btnOK.Location = new System.Drawing.Point(409, 615);
             this.m_btnOK.Name = "m_btnOK";
             this.m_btnOK.Size = new System.Drawing.Size(75, 23);
             this.m_btnOK.TabIndex = 100;
@@ -140,7 +146,7 @@
             this.m_tabOptions.Controls.Add(this.m_grpAutoSync);
             this.m_tabOptions.Location = new System.Drawing.Point(4, 23);
             this.m_tabOptions.Name = "m_tabOptions";
-            this.m_tabOptions.Size = new System.Drawing.Size(552, 423);
+            this.m_tabOptions.Size = new System.Drawing.Size(552, 516);
             this.m_tabOptions.TabIndex = 3;
             this.m_tabOptions.Text = "Title_DefaultsTab";
             this.m_tabOptions.UseVisualStyleBackColor = true;
@@ -446,13 +452,14 @@
             // m_tabGSignIn
             // 
             this.m_tabGSignIn.Controls.Add(this.m_grpAuthTokenSecurity);
+            this.m_tabGSignIn.Controls.Add(this.m_grpFileScope);
             this.m_tabGSignIn.Controls.Add(this.m_grpDriveAuth);
             this.m_tabGSignIn.Controls.Add(this.m_grpEntry);
             this.m_tabGSignIn.Controls.Add(this.m_grpDriveOptions);
             this.m_tabGSignIn.Location = new System.Drawing.Point(4, 23);
             this.m_tabGSignIn.Name = "m_tabGSignIn";
             this.m_tabGSignIn.Padding = new System.Windows.Forms.Padding(3);
-            this.m_tabGSignIn.Size = new System.Drawing.Size(552, 423);
+            this.m_tabGSignIn.Size = new System.Drawing.Size(552, 516);
             this.m_tabGSignIn.TabIndex = 0;
             this.m_tabGSignIn.Text = "Title_SyncAuthTab";
             this.m_tabGSignIn.UseVisualStyleBackColor = true;
@@ -461,7 +468,7 @@
             // 
             this.m_grpAuthTokenSecurity.Controls.Add(this.m_lnkAuthTokenHelp);
             this.m_grpAuthTokenSecurity.Controls.Add(this.m_chkDontSaveAuthToken);
-            this.m_grpAuthTokenSecurity.Location = new System.Drawing.Point(6, 182);
+            this.m_grpAuthTokenSecurity.Location = new System.Drawing.Point(6, 271);
             this.m_grpAuthTokenSecurity.Name = "m_grpAuthTokenSecurity";
             this.m_grpAuthTokenSecurity.Size = new System.Drawing.Size(540, 80);
             this.m_grpAuthTokenSecurity.TabIndex = 2;
@@ -490,6 +497,54 @@
             this.m_chkDontSaveAuthToken.Text = "Lbl_DontSaveAuthToken";
             this.m_chkDontSaveAuthToken.UseVisualStyleBackColor = true;
             // 
+            // m_grpFileScope
+            // 
+            this.m_grpFileScope.Controls.Add(this.m_btnSelectFile);
+            this.m_grpFileScope.Controls.Add(this.m_txtFile);
+            this.m_grpFileScope.Controls.Add(this.m_lblTargetFile);
+            this.m_grpFileScope.Controls.Add(this.m_chkUseFileScope);
+            this.m_grpFileScope.Location = new System.Drawing.Point(6, 182);
+            this.m_grpFileScope.Name = "m_grpFileScope";
+            this.m_grpFileScope.Size = new System.Drawing.Size(540, 83);
+            this.m_grpFileScope.TabIndex = 2;
+            this.m_grpFileScope.TabStop = false;
+            // 
+            // m_btnSelectFile
+            // 
+            this.m_btnSelectFile.Location = new System.Drawing.Point(426, 33);
+            this.m_btnSelectFile.Name = "m_btnSelectFile";
+            this.m_btnSelectFile.Size = new System.Drawing.Size(96, 23);
+            this.m_btnSelectFile.TabIndex = 34;
+            this.m_btnSelectFile.Text = "Btn_SelectFile";
+            this.m_btnSelectFile.UseVisualStyleBackColor = true;
+            // 
+            // m_txtFile
+            // 
+            this.m_txtFile.Location = new System.Drawing.Point(131, 35);
+            this.m_txtFile.Name = "m_txtFile";
+            this.m_txtFile.Size = new System.Drawing.Size(289, 20);
+            this.m_txtFile.TabIndex = 33;
+            // 
+            // m_lblTargetFile
+            // 
+            this.m_lblTargetFile.Location = new System.Drawing.Point(18, 38);
+            this.m_lblTargetFile.Name = "m_lblTargetFile";
+            this.m_lblTargetFile.Size = new System.Drawing.Size(104, 13);
+            this.m_lblTargetFile.TabIndex = 32;
+            this.m_lblTargetFile.Text = "Lbl_TargetFile";
+            this.m_lblTargetFile.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // m_chkUseFileScope
+            // 
+            this.m_chkUseFileScope.AutoSize = true;
+            this.m_chkUseFileScope.Location = new System.Drawing.Point(6, 0);
+            this.m_chkUseFileScope.Name = "m_chkUseFileScope";
+            this.m_chkUseFileScope.Size = new System.Drawing.Size(112, 17);
+            this.m_chkUseFileScope.TabIndex = 31;
+            this.m_chkUseFileScope.Text = "Lbl_UseFileScope";
+            this.m_chkUseFileScope.UseVisualStyleBackColor = true;
+            this.m_chkUseFileScope.CheckedChanged += new System.EventHandler(this.m_UseFileScope_CheckedChanged);
+            // 
             // m_grpDriveAuth
             // 
             this.m_grpDriveAuth.Controls.Add(this.m_chkUseLegacyCreds);
@@ -501,9 +556,9 @@
             this.m_grpDriveAuth.Controls.Add(this.m_lblClientId);
             this.m_grpDriveAuth.Controls.Add(this.m_txtClientSecret);
             this.m_grpDriveAuth.Controls.Add(this.m_txtClientId);
-            this.m_grpDriveAuth.Location = new System.Drawing.Point(6, 268);
+            this.m_grpDriveAuth.Location = new System.Drawing.Point(6, 357);
             this.m_grpDriveAuth.Name = "m_grpDriveAuth";
-            this.m_grpDriveAuth.Size = new System.Drawing.Size(540, 149);
+            this.m_grpDriveAuth.Size = new System.Drawing.Size(540, 153);
             this.m_grpDriveAuth.TabIndex = 4;
             this.m_grpDriveAuth.TabStop = false;
             // 
@@ -533,7 +588,7 @@
             this.m_lnkGoogle.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.m_lnkGoogle.AutoSize = true;
             this.m_lnkGoogle.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
-            this.m_lnkGoogle.Location = new System.Drawing.Point(187, 129);
+            this.m_lnkGoogle.Location = new System.Drawing.Point(187, 133);
             this.m_lnkGoogle.Name = "m_lnkGoogle";
             this.m_lnkGoogle.Size = new System.Drawing.Size(85, 13);
             this.m_lnkGoogle.TabIndex = 6;
@@ -545,7 +600,7 @@
             this.m_lnkHelp.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
             this.m_lnkHelp.AutoSize = true;
             this.m_lnkHelp.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
-            this.m_lnkHelp.Location = new System.Drawing.Point(128, 129);
+            this.m_lnkHelp.Location = new System.Drawing.Point(128, 133);
             this.m_lnkHelp.Name = "m_lnkHelp";
             this.m_lnkHelp.Size = new System.Drawing.Size(53, 13);
             this.m_lnkHelp.TabIndex = 5;
@@ -671,7 +726,7 @@
             this.m_tabMain.Location = new System.Drawing.Point(12, 66);
             this.m_tabMain.Name = "m_tabMain";
             this.m_tabMain.SelectedIndex = 0;
-            this.m_tabMain.Size = new System.Drawing.Size(560, 450);
+            this.m_tabMain.Size = new System.Drawing.Size(560, 543);
             this.m_tabMain.TabIndex = 0;
             // 
             // m_tabAbout
@@ -687,7 +742,7 @@
             this.m_tabAbout.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.m_tabAbout.Location = new System.Drawing.Point(4, 23);
             this.m_tabAbout.Name = "m_tabAbout";
-            this.m_tabAbout.Size = new System.Drawing.Size(552, 423);
+            this.m_tabAbout.Size = new System.Drawing.Size(552, 516);
             this.m_tabAbout.TabIndex = 4;
             this.m_tabAbout.Text = "Title_AboutTab";
             // 
@@ -766,7 +821,7 @@
             // m_aboutPic
             // 
             this.m_aboutPic.ErrorImage = null;
-            this.m_aboutPic.Image = KPSyncForDrive.Images.gdsync;
+            this.m_aboutPic.Image = global::KPSyncForDrive.Images.gdsync;
             this.m_aboutPic.InitialImage = null;
             this.m_aboutPic.Location = new System.Drawing.Point(11, 80);
             this.m_aboutPic.Name = "m_aboutPic";
@@ -793,7 +848,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(580, 557);
+            this.ClientSize = new System.Drawing.Size(580, 650);
             this.Controls.Add(this.m_btnCancel);
             this.Controls.Add(this.m_btnOK);
             this.Controls.Add(this.m_tabMain);
@@ -819,6 +874,8 @@
             this.m_tabGSignIn.ResumeLayout(false);
             this.m_grpAuthTokenSecurity.ResumeLayout(false);
             this.m_grpAuthTokenSecurity.PerformLayout();
+            this.m_grpFileScope.ResumeLayout(false);
+            this.m_grpFileScope.PerformLayout();
             this.m_grpDriveAuth.ResumeLayout(false);
             this.m_grpDriveAuth.PerformLayout();
             this.m_grpEntry.ResumeLayout(false);
@@ -900,5 +957,10 @@
         private System.Windows.Forms.CheckBox m_chkWarnAuthToken;
         private System.Windows.Forms.CheckBox m_chkDontSaveAuthDefault;
         private System.Windows.Forms.CheckBox m_chkSyncOnReopen;
+        private System.Windows.Forms.CheckBox m_chkUseFileScope;
+        private System.Windows.Forms.GroupBox m_grpFileScope;
+        private System.Windows.Forms.Label m_lblTargetFile;
+        private System.Windows.Forms.Button m_btnSelectFile;
+        private System.Windows.Forms.TextBox m_txtFile;
     }
 }

--- a/src/ConfigurationForm.cs
+++ b/src/ConfigurationForm.cs
@@ -49,6 +49,7 @@ namespace KPSyncForDrive
             EnsureCheckEnabledGroupBox(m_chkDefaultUseLegacyCreds,
                                         m_grpDriveAuthDefaults);
             EnsureCheckEnabledGroupBox(m_chkUseLegacyCreds, m_grpDriveAuth);
+            EnsureCheckEnabledGroupBox(m_chkUseFileScope, m_grpFileScope);
 
             Text = GdsDefs.ProductName;
             DatabaseFilePath = string.Empty;
@@ -110,6 +111,9 @@ namespace KPSyncForDrive
                 m_chkDontSaveAuthToken,
                 m_lnkAuthTokenHelp,
                 m_chkSyncOnReopen,
+                m_lblTargetFile,
+                m_chkUseFileScope,
+                m_btnSelectFile,
             };
             foreach (Control c in textCx)
             {
@@ -147,6 +151,13 @@ namespace KPSyncForDrive
             }
             m_btnGetColors.Enabled = string.IsNullOrWhiteSpace(m_txtFolderDefault.Text);
             m_bColorsQueried = false;
+
+            m_btnSelectFile.Click += HandleSelectFile;
+        }
+
+        private async void HandleSelectFile(object sender, EventArgs e)
+        {
+            await m_data.GetFile();
         }
 
         static void EnsureCheckEnabledGroupBox(CheckBox chk, GroupBox grp)
@@ -610,6 +621,11 @@ namespace KPSyncForDrive
         private void m_chkUseLegacyCreds_CheckedChanged(object sender, EventArgs e)
         {
             m_grpDriveAuth.Enabled = m_chkUseLegacyCreds.Checked;
+        }
+
+        private void m_UseFileScope_CheckedChanged(object sender, EventArgs e)
+        {
+            m_grpFileScope.Enabled = m_chkUseFileScope.Checked;
         }
     }
 }

--- a/src/ConfigurationForm.cs
+++ b/src/ConfigurationForm.cs
@@ -157,7 +157,8 @@ namespace KPSyncForDrive
 
         private async void HandleSelectFile(object sender, EventArgs e)
         {
-            await m_data.GetFile();
+            await m_data.PickFile();
+            m_data.EntryBindingSource.ResetBindings(false); // somewhat hacky way to refresh bound values to re-read datasource
         }
 
         static void EnsureCheckEnabledGroupBox(CheckBox chk, GroupBox grp)
@@ -339,6 +340,20 @@ namespace KPSyncForDrive
             binding.ControlUpdateMode = ControlUpdateMode.OnPropertyChanged;
             binding.DataSourceUpdateMode = DataSourceUpdateMode.OnPropertyChanged;
             m_chkSyncOnReopen.DataBindings.Add(binding);
+
+            // File scope options
+            Debug.Assert(m_chkUseFileScope is CheckBox);
+            binding = new Binding("Checked",
+                bindingSource,
+                "UseFileScope");
+            binding.DataSourceUpdateMode = DataSourceUpdateMode.OnPropertyChanged;
+            m_chkUseFileScope.DataBindings.Add(binding);
+            
+            Debug.Assert(m_txtTargetFile is TextBox);
+            binding = new Binding("Text",
+                bindingSource,
+                "FileScopeFileTarget");
+            m_txtTargetFile.DataBindings.Add(binding);
 
             // Select first "active" entry in the accounts combo.
             IEnumerable<EntryConfiguration> actives = m_data.Entries

--- a/src/ConfigurationFormData.cs
+++ b/src/ConfigurationFormData.cs
@@ -40,13 +40,17 @@ namespace KPSyncForDrive
         public delegate Task<IEnumerable<Color>> ColorProvider(
             EntryConfiguration ec, DatabaseContext dbCtx);
 
+        public delegate Task<FilePick> FilePicker(EntryConfiguration ec,
+            DatabaseContext dbCtx);
+
         IEnumerable<Color> m_colors;
         readonly ColorProvider m_colorProvider;
+        readonly FilePicker m_picker;
         readonly PwDatabase m_db;
         PluginConfig m_config;
 
         public ConfigurationFormData(IList<EntryConfiguration> entries,
-            ColorProvider colorProvider, PwDatabase db)
+            ColorProvider colorProvider, FilePicker picker, PwDatabase db)
         {
             Entries = entries;
             EntryBindingSource = new BindingSource
@@ -56,6 +60,7 @@ namespace KPSyncForDrive
 
             m_colors = null;
             m_colorProvider = colorProvider;
+            m_picker = picker;
             m_db = db;
             DefaultUseKpgs3ClientId = 
                 SyncConfiguration.IsEmpty(
@@ -346,6 +351,13 @@ namespace KPSyncForDrive
                 m_colors = result;
             }
             return m_colors;
+        }
+
+        public async Task<FilePick> GetFile()
+        {
+            EntryConfiguration current;
+            current = EntryBindingSource.Current as EntryConfiguration;
+            return await m_picker(current, new DatabaseContext(m_db));
         }
 
         void RaisePropertyChanged(string propName)

--- a/src/ConfigurationFormData.cs
+++ b/src/ConfigurationFormData.cs
@@ -353,11 +353,11 @@ namespace KPSyncForDrive
             return m_colors;
         }
 
-        public async Task<FilePick> GetFile()
+        public async Task PickFile()
         {
             EntryConfiguration current;
             current = EntryBindingSource.Current as EntryConfiguration;
-            return await m_picker(current, new DatabaseContext(m_db));
+            await m_picker(current, new DatabaseContext(m_db));
         }
 
         void RaisePropertyChanged(string propName)

--- a/src/FilePicker.cs
+++ b/src/FilePicker.cs
@@ -1,0 +1,184 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using KeePass.Plugins;
+using Newtonsoft.Json;
+
+namespace KPSyncForDrive
+{
+    class FilePicker
+    {
+        readonly SyncConfiguration m_entry;
+        readonly IPluginHost m_host;
+        readonly DatabaseContext m_dbCtx;
+        bool disposedValue;
+
+        // TODO: Add multiple options since these have to be added as authorized origins on Google API side.
+        static int[] m_allowedPorts = new int[] { 50100 };
+
+        private static int GetRandomAllowedPort()
+        {
+            var r = new Random();
+            return m_allowedPorts[r.Next(m_allowedPorts.Length)];
+        }
+
+        internal FilePicker(IPluginHost host, DatabaseContext dbCtx,
+            SyncConfiguration entry)
+        {
+            m_entry = entry;
+            m_host = host;
+            m_dbCtx = dbCtx;
+        }
+
+        public async Task<FilePick> SelectFile(CancellationToken cancellationToken)
+        {
+            // 1. SHOW PROMPT
+            // 2. START LISTENER
+            // 3. OPEN PAGE
+            // 4. WAIT FOR POST
+            // 5. RETURN Id/Name
+
+            // 1.
+            FilePick pick;
+            using (AuthWaitOrCancel form = new AuthWaitOrCancel(m_host, m_dbCtx, m_entry as EntryConfiguration))
+            {
+                using (var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
+                {
+                    var httpHandlerTask = HandleRequests(
+                        cts.Token,
+                        (uri) => {
+                            Log.Debug("Opening OS URL handler ('{0}').", uri);
+                            Process.Start(uri);
+                        },
+                        () => {
+                            if (!form.IsDisposed)
+                            {
+                                Log.Debug("Attempting to close waiter dialog.");
+                                form.Invoke(new MethodInvoker(form.Close));
+                            }
+                        }
+                    );
+
+                    // Wait for dialog.
+                    form.FormClosing += (o, e) => { Log.Debug("Closing"); if (!cts.IsCancellationRequested) { cts.Cancel(); }};
+
+                    DialogResult dr = KPSyncForDriveExt.ShowModalDialogAndDestroy(form);
+
+                    Log.Debug("Waiting.");
+                    pick = await httpHandlerTask;
+                    Log.Debug("Picked.");
+                    cts.Cancel();
+
+                    Log.Debug("Wait dialog returned '{0}'.", dr.ToString("G"));
+                }
+            }
+
+            // Bring main KeePass window back.
+            Log.Debug("Activating KP main window.");
+            Form window = m_host.MainWindow;
+            window.BeginInvoke(new MethodInvoker(window.Activate));
+ 
+            return pick;
+        }
+
+        private async Task<FilePick> HandleRequests(CancellationToken cancellationToken, Action<string> onListenerStart, Action onPicked)
+        {
+            var uri = string.Format("{0}:{1}/", "http://localhost", GetRandomAllowedPort());
+
+            using (var listener = new HttpListener())
+            {
+                listener.Prefixes.Add(uri);
+                try
+                {
+                    listener.Start();                    
+                }
+                catch (HttpListenerException ex)
+                {
+                    Log.Error("Failed to start HttpListener with error code: {0}", ex.ErrorCode);
+                    return null;
+                }
+
+                Log.Debug("Listening for '{0}'...", uri);
+
+                onListenerStart(uri);
+
+                var pageBuffer = Resources.ReadByteResourceFromAssembly("Pages.picker.html");
+
+                using (var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
+                {
+                    cts.CancelAfter(TimeSpan.FromMinutes(5)); // Give 5 minutes or otherwise cancel.
+                    cts.Token.Register(() => listener.Stop());
+
+                    while (!cts.Token.IsCancellationRequested)
+                    {
+                        // task completes when request is received, thus in order to react to
+                        // cancellations we can't just await it directly.
+                        Log.Debug("starting to get context");
+                        
+                        HttpListenerContext context = null;
+                        try
+                        {
+                            context = await listener.GetContextAsync();
+                        }
+                        catch (HttpListenerException ex)
+                        {
+                            Log.Error("Failed to get context: {0}", ex.ErrorCode);
+                        }
+
+                        Log.Debug("got context");
+                        if (context == null)
+                        {
+                            Log.Debug("Assuming user cancelled the listener.");
+                            break;
+                        }
+
+                        if (context.Request.HttpMethod == "POST") {
+                            using (var sr = new StreamReader(context.Request.InputStream))
+                            {
+                                var input = await sr.ReadToEndAsync();
+                                FilePick pick = null;
+                                try
+                                {
+                                    pick = JsonConvert.DeserializeObject<FilePick>(input);
+                                    Log.Debug("Picked {0}, {1}", pick.Id, pick.Name);
+                                }
+                                catch (JsonSerializationException ex) {
+                                    Log.Error(ex, "Failed to deserialize file pick response");
+                                }
+
+                                var response = context.Response;
+                                response.StatusCode = 200;
+                                response.Close();
+
+                                Log.Debug("Returning picked {0}", pick.Id);
+                                onPicked();
+                                return pick;
+                            }
+                        } else {
+                            var response = context.Response;
+                            response.KeepAlive = false;
+                            response.ContentLength64 = pageBuffer.Length;
+                            using (Stream responseOutput = response.OutputStream)
+                            {
+                                await responseOutput.WriteAsync(pageBuffer, 0, pageBuffer.Length);
+                                Log.Debug("File picker page returned to browser.");
+                            }
+                        }
+                    }
+                }
+            }
+
+            onPicked();
+            return null;
+        }
+    }
+    
+    internal class FilePick {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/src/GoogleDriveSyncExt.cs
+++ b/src/GoogleDriveSyncExt.cs
@@ -1750,7 +1750,7 @@ namespace KPSyncForDrive
 
             // Create a "presentation" object for dialog data binding.
             ConfigurationFormData options;
-            options = new ConfigurationFormData(acctList, GetColors, db);
+            options = new ConfigurationFormData(acctList, GetColors, GetFile, db);
             ConfigurationForm optionsForm = new ConfigurationForm(options)
             {
                 DatabaseFilePath = db.IOConnectionInfo.Path
@@ -2071,6 +2071,12 @@ namespace KPSyncForDrive
             }
 
             return true;
+        }
+
+        async Task<FilePick> GetFile(SyncConfiguration authData, DatabaseContext dbCtx)
+        {
+            var picker = new FilePicker(m_host, dbCtx, authData);
+            return await picker.SelectFile(CancellationToken.None);
         }
     }
 

--- a/src/GoogleDriveSyncExt.cs
+++ b/src/GoogleDriveSyncExt.cs
@@ -1417,7 +1417,11 @@ namespace KPSyncForDrive
 
             // Scope choice only available with legacy creds.
             string scope;
-            if (config.UseLegacyCreds &&
+            if (config.UseFileScope)
+            {
+                scope = DriveService.Scope.DriveFile;
+            }
+            else if (config.UseLegacyCreds &&
                 !string.IsNullOrEmpty(config.LegacyDriveScope))
             {
                 Log.Debug("Requesting scope '{0}' for legacy app creds.",

--- a/src/GoogleDriveSyncExt.cs
+++ b/src/GoogleDriveSyncExt.cs
@@ -713,8 +713,16 @@ namespace KPSyncForDrive
                 status = null;
 
                 List<Folder> folders = await GetFolders(service, config.ActiveFolder);
-                GDriveFile file = await GetFile(service, folders, fileName, 
+                GDriveFile file;
+                if (config.UseFileScope)
+                {
+                    file = await GetFileDirect(service, config.FileScopeFileTargetId);
+                } else 
+                {
+                    file = await GetFile(service, folders, fileName, 
                                             config, autoSync);
+                }
+
                 if (file == null)
                 {
                     if (sync == SyncCommands.DOWNLOAD)
@@ -1022,6 +1030,13 @@ namespace KPSyncForDrive
                 }
             }
             return file;
+        }
+
+        async Task<GDriveFile> GetFileDirect(DriveService service, string fileId)
+        {
+            var req = service.Files.Get(fileId);
+            req.Fields = "id,name,mimeType,shortcutDetails/targetId,shared";
+            return await req.ExecuteAsync();
         }
 
         /// <summary>

--- a/src/KPSyncForDrive.csproj
+++ b/src/KPSyncForDrive.csproj
@@ -142,6 +142,8 @@
     <EmbeddedResource Update="Strings.resx">
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <EmbeddedResource Include="Pages/picker.html">
+    </EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Pages/picker.html
+++ b/src/Pages/picker.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta charset="utf-8" />
+    <title>Google Drive File Picker</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        min-height: 100vh;
+        justify-content: center;
+        align-items: center;
+      }
+
+      #picker_button {
+        width: fit-content;
+      }
+    </style>
+
+    <script type="text/javascript">
+
+    // The Browser API key obtained from the Google API Console.
+    // Replace with your own Browser API key, or your own key.
+    var developerKey = 'xx';
+
+    // The Client ID obtained from the Google API Console. Replace with your own Client ID.
+    // HAS TO BE WEB APPLICATION OAUTH2
+    var clientId = "xx";
+
+    // Replace with your own project number from console.developers.google.com.
+    // See "Project number" under "IAM & Admin" > "Settings"
+    var appId = "xx";
+
+    // Scope to use to access user's Drive items.
+    var scope = ['https://www.googleapis.com/auth/drive.file'];
+
+    var pickerApiLoaded = false;
+    var oauthToken;
+
+    // Use the Google API Loader script to load the google.picker script.
+    function loadPicker() {
+      gapi.load('auth', {'callback': onAuthApiLoad});
+      gapi.load('picker', {'callback': onPickerApiLoad});
+    }
+
+    function onAuthApiLoad() {
+      window.gapi.auth.authorize(
+          {
+            'client_id': clientId,
+            'scope': scope,
+            'immediate': false
+          },
+          handleAuthResult);
+    }
+
+    function onPickerApiLoad() {
+      pickerApiLoaded = true;
+      createPicker();
+    }
+
+    function handleAuthResult(authResult) {
+      console.log(authResult);
+      if (authResult && !authResult.error) {
+        oauthToken = authResult.access_token;
+        createPicker();
+      }
+    }
+
+    // Create and render a Picker object for searching images.
+    function createPicker() {
+      if (pickerApiLoaded && oauthToken) {
+        var picker = new google.picker.PickerBuilder()
+            .enableFeature(google.picker.Feature.NAV_HIDDEN)
+            .setAppId(appId)
+            .setOAuthToken(oauthToken)
+            .addView(new google.picker.View(google.picker.ViewId.DOCS))
+            .setDeveloperKey(developerKey)
+            .setCallback(pickerCallback)
+            .build();
+         picker.setVisible(true);
+      }
+    }
+
+    // A simple callback implementation.
+    function pickerCallback(data) {
+      if (data.action == google.picker.Action.PICKED) {
+        const { id, name } = data.docs[0];
+        fetch("/", {
+          method: "POST",
+          body: JSON.stringify({ id, name }),
+        })
+        .then(() => {
+          console.log('closing window');
+          window.close();
+        })
+        .catch(() => alert("Failed to send information to KeePass"));
+      }
+    }
+    </script>
+  </head>
+  <body>
+    <button id="picker_button" onclick="loadPicker()">Pick file</button>
+    <div id="result"></div>
+
+    <!-- The Google API Loader script. -->
+    <script type="text/javascript" src="https://apis.google.com/js/api.js"></script>
+  </body>
+</html>

--- a/src/Resources.cs
+++ b/src/Resources.cs
@@ -145,10 +145,15 @@ namespace KPSyncForDrive
 
         readonly ResourceManager m_strings;
         readonly ResourceManager m_images;
+        readonly ResourceManager m_pages;
+        readonly string m_namespace;
+        readonly Assembly m_assembly;
 
         Resources()
         {
             Type thisType = GetType();
+            m_namespace = thisType.Namespace;
+            m_assembly = thisType.Assembly;
             m_strings = new SingleAssemblyResourcesManager(
                 thisType.Namespace + ".Strings", thisType.Assembly);
             m_images = new ResourceManager(thisType.Namespace + ".Images", thisType.Assembly);
@@ -215,6 +220,16 @@ namespace KPSyncForDrive
         public static Bitmap GetBitmap(string name)
         {
             return (Bitmap)Instance.m_images.GetObject(name);
+        }
+
+        public static byte[] ReadByteResourceFromAssembly(string name)
+        {
+            using (var stream = Instance.m_assembly.GetManifestResourceStream(Instance.m_namespace + "." + name))
+            {
+                var buffer = new byte[stream.Length];
+                stream.Read(buffer, 0, (int)stream.Length);
+                return buffer;                
+            }
         }
 
         public static MemoryStream GetImageStream(string name, ImageFormat fmt)

--- a/src/Strings.resx
+++ b/src/Strings.resx
@@ -598,4 +598,13 @@ The local database could be out of sync with the Drive file.  Would you like to 
   <data name="Lbl_AutoSyncOnReopen" xml:space="preserve">
     <value>Resume on return from Auto-Lock or Exit</value>
   </data>
+  <data name="Lbl_UseFileScope" xml:space="preserve">
+    <value>Use Google Drive File Scope</value>
+  </data>
+  <data name="Lbl_TargetFile" xml:space="preserve">
+    <value>Database file path:</value>
+  </data>
+  <data name="Btn_SelectFile" xml:space="preserve">
+    <value>Select file</value>
+  </data>
 </root>

--- a/src/SyncConfiguration.cs
+++ b/src/SyncConfiguration.cs
@@ -64,6 +64,9 @@ namespace KPSyncForDrive
         public const string EntryUseLegacyCredsKey = "GoogleSync.UseLegacyAppCreds";
         public const string EntryVersionKey = "GoogleSync.ConfigVersion";
         public const string EntryDontCacheAuthTokenKey = "GoogleSync.NoAuthTokens";
+        public const string EntryUseFileScope = "GoogleSync.UseFileScope";
+        public const string EntryFileScopeFileTarget = "GoogleSync.FileScopeFileTarget";
+        public const string EntryFileScopeFileTargetId = "GoogleSync.FileScopeFileTargetId";
 
         public static Version CurrentVersion
         {
@@ -120,6 +123,12 @@ namespace KPSyncForDrive
         public abstract string LegacyDriveScope { get; set; }
         public abstract bool UseLegacyCreds { get; set; }
         public abstract bool DontSaveAuthToken { get; set; }
+
+
+        public abstract bool UseFileScope { get; set; }
+        public abstract string FileScopeFileTarget { get; set; }
+        public abstract string FileScopeFileTargetId { get; set; }
+
         public abstract Version Version { get; }
     }
 
@@ -167,6 +176,11 @@ namespace KPSyncForDrive
             m_title = copyee.Title;
             ActiveFolder = copyee.ActiveFolder;
             LegacyDriveScope = copyee.LegacyDriveScope;
+
+            UseFileScope = copyee.UseFileScope;
+            FileScopeFileTarget = copyee.FileScopeFileTarget;
+            FileScopeFileTargetId = copyee.FileScopeFileTargetId;
+
             m_ver = copyee.Version;
         }
 
@@ -222,6 +236,12 @@ namespace KPSyncForDrive
         {
             get { return m_ver; }
         }
+
+        public override bool UseFileScope { get; set; }
+
+        public override string FileScopeFileTarget { get; set; }
+
+        public override string FileScopeFileTargetId { get; set; }
     }
 
     /// <summary>
@@ -302,6 +322,9 @@ namespace KPSyncForDrive
                         case EntryDriveScopeKey:
                         case EntryVersionKey:
                         case EntryDontCacheAuthTokenKey:
+                        case EntryUseFileScope:
+                        case EntryFileScopeFileTarget:
+                        case EntryFileScopeFileTargetId:
                             string stringVal = kv.Value as string;
                             CustomData.Set(kv.Key, 
                                 stringVal == null ? string.Empty : stringVal);
@@ -708,6 +731,47 @@ namespace KPSyncForDrive
             }
         }
 
+        public override bool UseFileScope
+        {
+            get
+            {
+                return GdsDefs.ConfigTrue ==
+                    GetValue(EntryUseFileScope, ReadSafe);
+            }
+            set
+            {
+                SetValue(EntryUseFileScope,
+                    value ? GdsDefs.ConfigTrue : GdsDefs.ConfigFalse);
+            }
+        }
+
+        public override string FileScopeFileTarget
+        {
+            get
+            {
+                return GetValue(EntryFileScopeFileTarget, ReadSafe);
+            }
+            set
+            {
+                // when file name is updated reset id
+                // mainly when user decides to manually enter name
+                SetValue(EntryFileScopeFileTarget, value);
+                SetValue(EntryFileScopeFileTargetId, (string)null); // reset Id when name is changed.
+            }
+        }
+
+        public override string FileScopeFileTargetId
+        {
+            get
+            {
+                return GetValue(EntryFileScopeFileTargetId, ReadSafe);
+            }
+            set
+            {
+                SetValue(EntryFileScopeFileTargetId, value);
+            }
+        }
+
         public override Version Version
         {
             get
@@ -746,6 +810,12 @@ namespace KPSyncForDrive
             }
 
             Debug.Assert(Version == CurrentVersion);
+        }
+
+        public class FileScopeFile
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
         }
     }
 }


### PR DESCRIPTION
As per #42 I finally got around trying to implement this. As per my testing everything more or less works and the file scope seems to work as expected, only giving files that were picked. Adding this bit to somewhere will print out only 1 or how many files were picked.
```csharp
var available = service.Files.List();
available.Fields = "files(id,name)";
var result = await available.ExecuteAsync();
foreach (var item in result.Files)
{
    Log.Info("Got {0}/{1}", item.Id, item.Name);
}
```

Some difficult parts:
- Needs API Key, as explained in https://developers.google.com/picker/docs#appreg API key has to be provided when file picker is created, so that would mean that it would either be patched it when page is being served on baked in when plugin is being built.
- Having the local web server serve up the page. The problem is that file picker only allows web application oauth2 app, so it is impossible to reuse desktop app token. With that it requires authorized javascript origin, which means that there has to be a set of ports whitelisted beforehand and it can't just get any random available port.

I don't expect this to be merged, a lot of parts are quite rough around the edges, data flow is a bit incorrect IMO at some parts, but it's a good POC that it's not that hard to use file scope. This should have no issues working with any other apps as long as they don't completely delete the file and upload new one in gdrive.